### PR TITLE
Add Authorization Header Cache to Optimize Basic Auth Middleware

### DIFF
--- a/src/auth/basic_auth.rs
+++ b/src/auth/basic_auth.rs
@@ -4,51 +4,90 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use axum::{extract::{Request, State}, http::StatusCode, middleware::Next, response::Response};
 use base64::{engine::general_purpose, Engine};
+use tokio::sync::RwLock;
+
+#[derive(Clone)]
+pub struct Credential {
+    pub encoded: String,
+    pub decoded: String,
+}
 
 #[derive(Clone)]
 pub struct BasicAuth {
     pub credentials: HashMap<String, String>,
+    pub auth_header_cache: Arc<RwLock<Vec<String>>>,
 }
 
 impl BasicAuth {
-    fn verify(&self, auth_header: &str) -> bool {
-        log::debug!("Verifying Basic Auth header: {:?}", auth_header);
+    fn is_valid_basic_auth_header(auth_header: &str) -> Option<Credential> {
+        log::debug!("Checking if Authorization header is valid Basic Auth: {}", auth_header);
 
-        if auth_header.starts_with("Basic") && auth_header.len() > 6 {
-            let auth = match general_purpose::STANDARD.decode(&auth_header[6..]) {
-                Ok(bytes) =>  match String::from_utf8(bytes) {
-                    Ok(s) => s,
-                    Err(_) => {
-                        log::debug!("Failed to decode base64 to UTF-8");
-                        return false;
-                    },
-                },
-                Err(_) => {
-                    log::debug!("Failed to decode base64 from auth header");
-                    return false;
-                },
-            };
-
-            let user_pass: Vec<&str> = auth.split(":").collect();
-            if user_pass.len() != 2 {
-                log::debug!("Auth header does not contain user:pass");
-                return false;
-            }
-            let (user, pass) = (user_pass[0], user_pass[1]);
-            log::debug!("Parsed user: {}, pass: [REDACTED]", user);
-
-            if let Some(hash) = self.credentials.get(user) {
-                let verified = bcrypt::verify(pass, &hash).unwrap_or(false);
-                log::debug!("Password verification for user {}: {}", user, verified);
-                return verified;
-            } else {
-                log::debug!("User {} not found in credentials", user);
-            }
-        } else {
-            log::debug!("Auth header does not start with 'Basic' or is too short");
+        if !(auth_header.starts_with("Basic") && auth_header.len() > 6) {
+            log::debug!("Auth header does not start with `Basic` or is too short");
+            return None;
         }
 
-        false
+        let encoded= auth_header[6..].to_string();
+
+        let decoded = match general_purpose::STANDARD.decode(&encoded) {
+            Ok(bytes) =>  match String::from_utf8(bytes) {
+                Ok(s) => s,
+                Err(_) => {
+                    log::debug!("Failed to decode base64 to UTF-8");
+                    return None;
+                },
+            },
+            Err(_) => {
+                log::debug!("Failed to decode base64 from auth header");
+                return None;
+            },
+        };
+
+        let credential = Credential {
+            encoded,
+            decoded,
+        };
+
+        Some(credential)
+    }
+
+    fn parse_user_pass(&self, credential: &String) -> Option<(String, String)> {
+        let parts: Vec<&str> = credential.split(':').collect();
+
+        if parts.len() != 2 {
+            log::debug!("Credential does not contain a valid `user:pass` format");
+            return None;
+        }
+
+        let username = parts[0].to_string();
+        let password = parts[1].to_string();
+
+        log::debug!("Parsed username: {}, password: [REDACTED]", username);
+        Some((username, password))
+    }
+
+    async fn verify(&self, credential: Credential) -> bool {
+        let Some((username, password)) = self.parse_user_pass(&credential.decoded) else {
+            return false;
+        };
+
+        match self.credentials.get(&username) {
+            Some(hash) => {
+                let verified = bcrypt::verify(password, &hash).unwrap_or(false);
+
+                let mut cache = self.auth_header_cache.write().await;
+                if verified && !cache.contains(&credential.encoded) {
+                    cache.push(credential.encoded.clone());
+                }
+
+                log::debug!("Password verification for user {}: {}", username, verified);
+                verified
+            },
+            None => {
+                log::debug!("User {} not found in credentials", username);
+                false
+            }
+        }
     }
 }
 
@@ -57,31 +96,45 @@ pub async fn basic_auth(
     request: Request,
     next: Next
 ) -> Result<Response, StatusCode> {
-    let state = state.config.read().await;
+    let is_valid_userpass;
 
-    if state.basic_auth.credentials.is_empty() {
-        log::debug!("No credentials configured, skipping auth");
-        return Ok(next.run(request).await);
+    {
+        let state = state.config.read().await;
+
+        if state.basic_auth.credentials.is_empty() {
+            log::debug!("No credentials configured, skipping auth");
+            return Ok(next.run(request).await);
+        }
+
+        let auth_header = request.headers()
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|header| header.to_str().ok());
+    
+        let Some(auth_header) = auth_header else {
+            log::debug!("No Authorization header found");
+            return Err(StatusCode::UNAUTHORIZED)
+        };
+
+        let Some(credential) = BasicAuth::is_valid_basic_auth_header(auth_header) else {
+            return Err(StatusCode::UNAUTHORIZED)
+        };
+
+        {
+            let cache = state.basic_auth.auth_header_cache.read().await;
+            if cache.contains(&credential.encoded) {
+                log::debug!("Authorization header found in cache, skipping further verification");
+                return Ok(next.run(request).await);
+            }
+        }
+
+        is_valid_userpass = state.basic_auth.verify(credential).await;
     }
 
-    let auth_header = request.headers()
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|header| header.to_str().ok());
-
-    match auth_header {
-        Some(auth_header) => {
-            log::debug!("Authorization header found");
-            if state.basic_auth.verify(auth_header) {
-                log::debug!("Authorization successful");
-                Ok(next.run(request).await)
-            } else {
-                log::debug!("Authorization failed");
-                Err(StatusCode::UNAUTHORIZED)
-            }
-        },
-        None => {
-            log::debug!("No Authorization header found");
-            Err(StatusCode::UNAUTHORIZED)
-        }
+    if is_valid_userpass {
+        log::debug!("Authorization successful");
+        Ok(next.run(request).await)
+    } else {
+        log::debug!("Authorization failed");
+        Err(StatusCode::UNAUTHORIZED)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,9 +20,10 @@ impl AppConfig {
     fn new(config: Config) -> Self {
         let credentials = config.basic_auth_users.clone();
         let scrape_timeout_seconds = config.scrape_configs.scrape_timeout_seconds;
+        let auth_header_cache: Arc<RwLock<Vec::<String>>> = Arc::new(RwLock::new(Vec::new()));
 
         Self {
-            basic_auth: BasicAuth { credentials },
+            basic_auth: BasicAuth { credentials, auth_header_cache },
             scrape_timeout_seconds,
         }
     }


### PR DESCRIPTION
Key changes:
- Added `auth_header_cache` to `BasicAuth` as an `RwLock` for thread-safe access.
- Updated the `verify` method to check the cache before performing credential verification.
- Modified the `basic_auth` middleware to utilize the cache, skipping verification if the header is already cached.

Benefits:
- Reduces the computational overhead of repeatedly verifying the same credentials.
- Improves performance for high-frequency requests with identical authorization headers.

This change ensures better scalability and efficiency for the authentication process.